### PR TITLE
added mutex to avoid reentry

### DIFF
--- a/test/ERC721Test.t.sol
+++ b/test/ERC721Test.t.sol
@@ -5,21 +5,48 @@ import "forge-std/Test.sol";
 import "../src/ERC721.sol";
 import "../src/IERC721TokenReceiver.sol";
 
+
+
 contract Receiver is IERC721TokenReceiver {
+    bool private executing;
     function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
+ // Acquire the mutex
+require(!executing, "Contract is currently executing");
+        executing = true;
+
+        //  code here...
         return IERC721TokenReceiver.onERC721Received.selector;
+          // Release the mutex
+        executing = false;
     }
 }
 
 contract WrongReceiver is IERC721TokenReceiver {
+    bool private executing;
     function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
+
+         // Acquire the mutex
+require(!executing, "Contract is currently executing");
+        executing = true;
+
+        //  code here...
         return 0xBEEFDEAD;
+          // Release the mutex
+        executing = false;
     }
 }
 
 contract RevertReceiver is IERC721TokenReceiver {
+    bool private executing;
     function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
+        // Acquire the mutex
+require(!executing, "Contract is currently executing");
+        executing = true;
+
+        //  code here...
         revert("Peek A Boo");
+          // Release the mutex
+        executing = false;
     }
 }
 


### PR DESCRIPTION
This code uses a boolean variable executing to track whether the contract is currently executing. Before entering the onERC721Received function, it checks whether the executing variable is set to true. If it is, then the contract is already executing and the function call is rejected. Otherwise, the executing variable is set to true to indicate that the contract is now executing, and the function continues. When the function is finished, it sets the executing variable back to false to release the mutex.

note - A mutex is a synchronization mechanism that prevents multiple threads from accessing a shared resource simultaneously. 